### PR TITLE
 Fix flamegraph and report for Python 3.8

### DIFF
--- a/python-plprofiler/plprofiler/plprofiler_report.py
+++ b/python-plprofiler/plprofiler/plprofiler_report.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import base64
-import cgi
 import html
 import os
 import subprocess
@@ -20,7 +19,7 @@ class plprofiler_report:
         self.out("<html>")
         self.out("<head>")
         self.out("""  <meta charset="UTF-8"> """)
-        self.out("  <title>%s</title>" %(cgi.escape(config['title']), ))
+        self.out("  <title>%s</title>" %(html.escape(config['title']), ))
         self.out(HTML_SCRIPT)
         self.out(HTML_STYLE)
         self.out("</head>")

--- a/python-plprofiler/plprofiler/plprofiler_report.py
+++ b/python-plprofiler/plprofiler/plprofiler_report.py
@@ -2,6 +2,7 @@
 
 import base64
 import cgi
+import html
 import os
 import subprocess
 import sys
@@ -18,6 +19,7 @@ class plprofiler_report:
 
         self.out("<html>")
         self.out("<head>")
+        self.out("""  <meta charset="UTF-8"> """)
         self.out("  <title>%s</title>" %(cgi.escape(config['title']), ))
         self.out(HTML_SCRIPT)
         self.out(HTML_STYLE)
@@ -106,7 +108,7 @@ class plprofiler_report:
             if line['line_number'] == 0:
                 src = "<b>--&nbsp;Function&nbsp;Totals</b>"
             else:
-                src = cgi.escape(line['source'].expandtabs(int(config['tabstop']))).replace(" ", "&nbsp;")
+                src = html.escape(line['source'].expandtabs(int(config['tabstop']))).replace(" ", "&nbsp;")
             self.out("""  <tr>""")
             self.out("""    <td align="right"><code>{val}</code></td>""".format(val = line['line_number']))
             self.out("""    <td align="right">{val}</td>""".format(val = line['exec_count']))
@@ -134,8 +136,9 @@ class plprofiler_report:
         if proc.returncode != 0:
             raise Exception("flamegraph returned with exit code %d\n%s" %(
                     proc.returncode, str(err)))
-        return str(svg)
-        # return "\n".join(svg.split("\n")[2:])
+        
+        # Decode binary utf8 to string and remove leading xml declaration from SVG
+        return "\n".join(svg.decode('utf8').split("\n")[2:])
 
     def out(self, line):
         self.outfd.write(line + '\n')


### PR DESCRIPTION
cgi.escape has been deprecated since Python 3.2 and is gone in recent versions. Also turn SVG into a string object, without leading b' prefix, so that flamegraph doesn't fail to behave.

Let me know if Python 2 compatibility is still important to you, and I'll make a new PR with cross-compatible versions of the changes.